### PR TITLE
feat: add automatic documentation configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,6 @@ repos:
     hooks:
       - id: commitlint
         additional_dependencies: ['@commitlint/config-conventional']
+
+ci:
+  skip: [terraform_fmt, terraform_fmt, terraform_tfsec, commitlint]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,18 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.2
+    rev: v1.73.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
       - id: terraform_tfsec
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: v0.16.0
+    hooks:
+      - id: terraform-docs-go
+        args: ["--output-file", "README.md", "."]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.16.1
+    rev: 0.16.2
     hooks:
       - id: check-github-actions
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
         additional_dependencies: ['@commitlint/config-conventional']
 
 ci:
-  skip: [terraform_fmt, terraform_fmt, terraform_tfsec, commitlint]
+  skip: [terraform_fmt, terraform_validate, terraform_tfsec, commitlint]

--- a/.terraform.docs.yml
+++ b/.terraform.docs.yml
@@ -1,0 +1,44 @@
+formatter: "markdown table"
+
+version: "" # Set with repo version
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+
+sections:
+  hide: []
+  show: []
+
+content: ""
+
+output:
+  file: "docs/README.md"
+  mode: inject
+  template: |-
+    <!--- Begin_TF_DOCS --->
+    {{ .Content }}
+    <!--- End_TF_DOCS --->
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: true
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit) [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/brucellino/tfmod-template/main.svg)](https://results.pre-commit.ci/latest/github/brucellino/tfmod-template/main)
+
 # tfmod-template
 
 <!-- Delete this section when using the template repository -->


### PR DESCRIPTION
This adds a configuration file for [`terraform-docs`](https://terraform-docs.io/) to keep docs up to date.